### PR TITLE
Fix pip install line in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It will also save these users to two distinct Twitter lists in case you'd like t
 Installation
 ------------
 
-    pip install restmapper requests-oauthlib pytz twitter-cleanse
+    pip install python-dateutil restmapper requests-oauthlib pytz twitter-cleanse
 
 Running
 -------


### PR DESCRIPTION
Tried to run with pip and this library was missing for me, fixed it.
